### PR TITLE
feat: make company fetching optional in dashboard layout

### DIFF
--- a/src/app/dashboard/companies/[id]/quotes/[quoteId]/edit/page.tsx
+++ b/src/app/dashboard/companies/[id]/quotes/[quoteId]/edit/page.tsx
@@ -176,7 +176,7 @@ export default function QuoteEditPage() {
 
   if (loading) {
     return (
-      <DashboardLayout>
+      <DashboardLayout fetchCompanies={false}>
         <div className="h-[60vh] grid place-items-center">
           <div className="text-center space-y-4">
             <Loader2 className="h-8 w-8 animate-spin mx-auto text-primary" />
@@ -194,7 +194,7 @@ export default function QuoteEditPage() {
 
   if (error || !quote) {
     return (
-      <DashboardLayout>
+      <DashboardLayout fetchCompanies={false}>
         <div className="h-[60vh] grid place-items-center">
           <div className="text-center space-y-4 max-w-md">
             <div className="p-4 rounded-full bg-destructive/10 w-fit mx-auto">
@@ -237,6 +237,7 @@ export default function QuoteEditPage() {
 
   return (
     <DashboardLayout
+      fetchCompanies={false}
       title={
         <div className="flex items-center gap-3">
           <div>

--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -22,6 +22,7 @@ interface DashboardLayoutProps {
   breadcrumbs?: BreadcrumbItem[];
   actions?: React.ReactNode;
   className?: string;
+  fetchCompanies?: boolean;
 }
 
 // Componente interno que usa o CompanyContext
@@ -73,6 +74,7 @@ export function DashboardLayout({
   breadcrumbs,
   actions,
   className = "",
+  fetchCompanies = true,
 }: DashboardLayoutProps) {
   const { isAuthenticated, isLoading, validateSession } = useAuth();
   const router = useRouter();
@@ -116,7 +118,7 @@ export function DashboardLayout({
 
   // Envolve todo o dashboard com o CompanyProvider
   return (
-    <CompanyProvider>
+    <CompanyProvider autoFetch={fetchCompanies}>
       <DashboardContent
         title={title}
         description={description}

--- a/src/contexts/CompanyContext.tsx
+++ b/src/contexts/CompanyContext.tsx
@@ -11,12 +11,16 @@ const CompanyContext = createContext<CompanyContextType | undefined>(undefined);
 // Provider Props
 interface CompanyProviderProps {
   children: ReactNode;
+  autoFetch?: boolean;
 }
 
 // Provider Component
-export function CompanyProvider({ children }: CompanyProviderProps) {
+export function CompanyProvider({
+  children,
+  autoFetch = true,
+}: CompanyProviderProps) {
   const companiesData = useCompanies({
-    autoFetch: true,
+    autoFetch,
     params: {
       pageSize: 50, // Busca mais empresas por vez
     },


### PR DESCRIPTION
## Summary
- allow CompanyProvider to be configured with an `autoFetch` flag
- add `fetchCompanies` option to DashboardLayout and pass through to CompanyProvider
- disable automatic company fetching in quote editing page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, missing dependencies and other lint errors)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689f4062690c832187a5dcb2bd30d50c