### PR TITLE
feat: allow company logo upload

### DIFF
--- a/src/app/dashboard/companies/[id]/page.tsx
+++ b/src/app/dashboard/companies/[id]/page.tsx
@@ -54,10 +54,12 @@ export default function CompanyDetailPage() {
     isLoading,
     isUpdating,
     isDeleting,
+    isUploadingLogo,
     error,
     fetchCompany,
     updateCompany,
     deleteCompany,
+    uploadLogo,
   } = useCompanyDetail(companyId);
 
   // Form setup
@@ -249,7 +251,12 @@ export default function CompanyDetailPage() {
     <DashboardLayout breadcrumbs={breadcrumbs} actions={actions}>
       <div className="space-y-6 px-4 py-6 md:px-6">
         {/* Header com avatar e status */}
-        <CompanyHeaderSection company={company} isLoading={isLoading} />
+        <CompanyHeaderSection
+          company={company}
+          isLoading={isLoading}
+          onLogoUpload={uploadLogo}
+          isUploadingLogo={isUploadingLogo}
+        />
 
         {/* Formulário de edição */}
         <form onSubmit={form.handleSubmit(handleSave)} className="space-y-6">

--- a/src/components/company/CompanyHeaderSection.tsx
+++ b/src/components/company/CompanyHeaderSection.tsx
@@ -6,15 +6,20 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { FileText } from "lucide-react";
 import type { CompanyApiResponse } from "@/hooks/useCompanyDetail";
 import { formatCNPJ, detectDocumentType } from "@/lib/format-utils";
+import { toast } from "sonner";
 
 interface CompanyHeaderSectionProps {
   company: CompanyApiResponse | null;
   isLoading: boolean;
+  onLogoUpload?: (file: File) => Promise<boolean>;
+  isUploadingLogo?: boolean;
 }
 
 export function CompanyHeaderSection({
   company,
   isLoading,
+  onLogoUpload,
+  isUploadingLogo,
 }: CompanyHeaderSectionProps) {
   const getCompanyInitials = (name: string) => {
     return name
@@ -72,15 +77,36 @@ export function CompanyHeaderSection({
     <Card>
       <CardHeader>
         <div className="flex items-start space-x-6">
-          <Avatar className="h-20 w-20">
-            <AvatarImage
-              src={company.logo_url || undefined}
-              alt={company.name}
-            />
-            <AvatarFallback className="text-xl">
-              {getCompanyInitials(company.name)}
-            </AvatarFallback>
-          </Avatar>
+          <div className="relative">
+            <Avatar className="h-20 w-20">
+              <AvatarImage
+                src={company.logo_url || undefined}
+                alt={company.name}
+              />
+              <AvatarFallback className="text-xl">
+                {getCompanyInitials(company.name)}
+              </AvatarFallback>
+            </Avatar>
+            {onLogoUpload && (
+              <input
+                type="file"
+                accept="image/*"
+                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                onChange={async (e) => {
+                  const file = e.target.files?.[0];
+                  if (!file) return;
+                  const success = await onLogoUpload(file);
+                  if (success) {
+                    toast.success("Logo atualizada");
+                  } else {
+                    toast.error("Erro ao atualizar logo");
+                  }
+                  e.target.value = "";
+                }}
+                disabled={isUploadingLogo}
+              />
+            )}
+          </div>
 
           <div className="flex-1 space-y-3">
             <div>


### PR DESCRIPTION
## Summary
- enable uploading company logos via API
- expose upload UI on company detail header
- wire company page to handle logo uploads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type. @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68a64477b0ec8321b5f03261db017130