### PR TITLE
fix pdf route param handling for Next.js 15

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    serverComponentsExternalPackages: ["knex", "pg"],
-  },
+  serverExternalPackages: ["knex", "pg"],
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,


### PR DESCRIPTION
## Summary
- handle dynamic params as promises in PDF API route
- update next.js config for serverExternalPackages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: various existing lint errors)*
- `npx eslint src/app/api/quotes/[quoteId]/pdf/route.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a6fa357d30832181fe24992df9b8db