### PR TITLE
feat: generate quote PDF via external service

### DIFF
--- a/src/components/quotes/view/QuoteViewHeader.tsx
+++ b/src/components/quotes/view/QuoteViewHeader.tsx
@@ -18,7 +18,6 @@ import {
   formatDateForDisplay,
 } from "@/lib/quote-utils";
 import {
-  Download,
   FileText,
   MoreHorizontal,
   Pencil,
@@ -35,9 +34,12 @@ import {
   User,
   DollarSign,
   Package,
+  Loader2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useState } from "react";
+import { useQuotes } from "@/hooks/useQuotes";
+import type { Quote } from "@/types/apiInterfaces";
 
 type Props = {
   companyId: string;
@@ -47,6 +49,8 @@ type Props = {
 
 export function QuoteViewHeader({ companyId, quote, onEdit }: Props) {
   const [copied, setCopied] = useState(false);
+  const [generatingPdf, setGeneratingPdf] = useState(false);
+  const { generatePdf } = useQuotes({ companyId });
 
   // Calcular status da validade
   const getExpiryStatus = () => {
@@ -126,6 +130,15 @@ export function QuoteViewHeader({ companyId, quote, onEdit }: Props) {
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       console.error("Erro ao copiar link:", err);
+    }
+  };
+
+  const handleGeneratePdf = async () => {
+    setGeneratingPdf(true);
+    try {
+      await generatePdf(quote.id);
+    } finally {
+      setGeneratingPdf(false);
     }
   };
 
@@ -314,9 +327,16 @@ export function QuoteViewHeader({ companyId, quote, onEdit }: Props) {
                       {copied ? "Link copiado!" : "Copiar link"}
                     </DropdownMenuItem>
 
-                    <DropdownMenuItem>
-                      <FileText className="h-4 w-4 mr-2" />
-                      Gerar PDF
+                    <DropdownMenuItem
+                      onClick={() => void handleGeneratePdf()}
+                      disabled={generatingPdf}
+                    >
+                      {generatingPdf ? (
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      ) : (
+                        <FileText className="h-4 w-4 mr-2" />
+                      )}
+                      {generatingPdf ? "Gerando..." : "Gerar PDF"}
                     </DropdownMenuItem>
 
                 

--- a/src/hooks/useQuotes.ts
+++ b/src/hooks/useQuotes.ts
@@ -359,12 +359,13 @@ export function useQuotes({ companyId }: UseQuotesOptions) {
       if (!companyId || !quoteId) return;
 
       try {
-        const { data: pdfData } =
+        const pdfResponse =
           await apiCall<{ title: string; data: Record<string, unknown> }>(
             `/companies/${companyId}/quotes/${quoteId}/pdf-data`,
             { method: "GET" }
           );
 
+        const pdfData = pdfResponse.data?.data ?? pdfResponse.data;
         if (!pdfData) {
           throw new Error("Dados do PDF não retornados");
         }

--- a/src/hooks/useQuotes.ts
+++ b/src/hooks/useQuotes.ts
@@ -359,15 +359,20 @@ export function useQuotes({ companyId }: UseQuotesOptions) {
       if (!companyId || !quoteId) return;
 
       try {
-        const pdfDataRes = await apiCall<{ title: string; data: Record<string, unknown> }>(
-          `/companies/${companyId}/quotes/${quoteId}/pdf-data`,
-          { method: "GET" }
-        );
+        const { data: pdfData } =
+          await apiCall<{ title: string; data: Record<string, unknown> }>(
+            `/companies/${companyId}/quotes/${quoteId}/pdf-data`,
+            { method: "GET" }
+          );
+
+        if (!pdfData) {
+          throw new Error("Dados do PDF não retornados");
+        }
 
         const payload = {
           type: "budget-premium",
-          title: pdfDataRes?.title ?? "Orçamento",
-          data: pdfDataRes?.data,
+          title: pdfData.title ?? "Orçamento",
+          data: pdfData.data,
           config: {
             format: "A4",
             orientation: "portrait",


### PR DESCRIPTION
## Summary
- add hook to request quote PDF generation and open returned link
- expose PDF generation in quote view menu with loading state

## Testing
- `npm run lint` *(fails: Unexpected any and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a76b7da0888321a7081b789425b75d