### PR TITLE
feat: add product CRUD page

### DIFF
--- a/src/components/products/ProductDeleteDialog.tsx
+++ b/src/components/products/ProductDeleteDialog.tsx
@@ -1,0 +1,83 @@
+// src/components/products/ProductDeleteDialog.tsx
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { useApi } from "@/hooks/useApi";
+import type { Product } from "@/types/product";
+import { toast } from "sonner";
+
+interface ProductDeleteDialogProps {
+  companyId: string;
+  product: Product;
+  onDeleted?: (id: string) => void;
+  children: React.ReactNode;
+}
+
+export function ProductDeleteDialog({
+  companyId,
+  product,
+  onDeleted,
+  children,
+}: ProductDeleteDialogProps) {
+  const { delete: deleteApi } = useApi();
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    const { error } = await deleteApi(
+      `/companies/${companyId}/products/${product.id}`
+    );
+    if (!error) {
+      toast.success("Produto excluído com sucesso");
+      onDeleted?.(product.id);
+      setOpen(false);
+    }
+    setIsDeleting(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Excluir produto</DialogTitle>
+          <DialogDescription>
+            Tem certeza que deseja excluir &quot;{product.name}&quot;? Esta ação não pode
+            ser desfeita.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={isDeleting}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={isDeleting}
+          >
+            {isDeleting ? "Excluindo..." : "Excluir"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default ProductDeleteDialog;

--- a/src/components/products/ProductDialog.tsx
+++ b/src/components/products/ProductDialog.tsx
@@ -1,0 +1,93 @@
+// src/components/products/ProductDialog.tsx
+"use client";
+
+import { useState, useCallback } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogTrigger } from "@/components/ui/dialog";
+import { ProductForm, ProductFormValues } from "./ProductForm";
+import { useApi } from "@/hooks/useApi";
+import type { Product } from "@/types/product";
+import { toast } from "sonner";
+
+interface ProductDialogProps {
+  companyId: string;
+  product?: Product;
+  trigger?: React.ReactNode;
+  onSuccess?: (product: Product) => void;
+}
+
+export function ProductDialog({ companyId, product, trigger, onSuccess }: ProductDialogProps) {
+  const { post, put } = useApi();
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (values: ProductFormValues) => {
+      setIsSubmitting(true);
+      const payload = {
+        name: values.name,
+        description: values.description || null,
+        sku: values.sku || null,
+        unit_price_cents: Math.round(values.unit_price * 100),
+        unit: values.unit || null,
+        is_active: values.is_active,
+      };
+
+      try {
+        const endpoint = product
+          ? `/companies/${companyId}/products/${product.id}`
+          : `/companies/${companyId}/products`;
+        const method = product ? put : post;
+        const { data, error } = await method<Product>(endpoint, payload);
+
+        if (error) {
+          return;
+        }
+
+        if (data) {
+          toast.success(
+            product ? "Produto atualizado com sucesso" : "Produto criado com sucesso"
+          );
+          onSuccess?.(data);
+          setOpen(false);
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [companyId, post, put, product, onSuccess]
+  );
+
+  const defaultValues = product
+    ? {
+        name: product.name,
+        description: product.description ?? "",
+        sku: product.sku ?? "",
+        unit_price: product.unit_price_cents / 100,
+        unit: product.unit ?? "",
+        is_active: product.is_active,
+      }
+    : undefined;
+
+  return (
+  <Dialog open={open} onOpenChange={setOpen}>
+    {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
+    <DialogContent className="max-w-lg">
+      <DialogHeader>
+        <DialogTitle>{product ? "Editar produto" : "Novo produto"}</DialogTitle>
+        <DialogDescription>
+          {product
+            ? "Atualize as informações do produto."
+            : "Preencha os dados para criar um novo produto."}
+        </DialogDescription>
+      </DialogHeader>
+      <ProductForm
+        defaultValues={defaultValues}
+        onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+      />
+    </DialogContent>
+  </Dialog>
+  );
+}
+
+export default ProductDialog;

--- a/src/components/products/ProductForm.tsx
+++ b/src/components/products/ProductForm.tsx
@@ -1,0 +1,96 @@
+// src/components/products/ProductForm.tsx
+"use client";
+
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+
+const productSchema = z.object({
+  name: z.string().min(1, "Nome é obrigatório"),
+  description: z.string().optional(),
+  sku: z.string().optional(),
+  unit_price: z.coerce.number().nonnegative(),
+  unit: z.string().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export type ProductFormValues = z.infer<typeof productSchema>;
+
+interface ProductFormProps {
+  defaultValues?: Partial<ProductFormValues>;
+  onSubmit: (values: ProductFormValues) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+export function ProductForm({ defaultValues, onSubmit, isSubmitting }: ProductFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ProductFormValues>({
+    resolver: zodResolver(productSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      sku: "",
+      unit_price: 0,
+      unit: "",
+      is_active: true,
+      ...defaultValues,
+    },
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <Label htmlFor="name">Nome</Label>
+        <Input id="name" {...register("name")} />
+        {errors.name && (
+          <p className="text-sm text-destructive">{errors.name.message}</p>
+        )}
+      </div>
+      <div>
+        <Label htmlFor="description">Descrição</Label>
+        <Textarea id="description" {...register("description")} />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="sku">SKU</Label>
+          <Input id="sku" {...register("sku")} />
+        </div>
+        <div>
+          <Label htmlFor="unit">Unidade</Label>
+          <Input id="unit" {...register("unit")} />
+        </div>
+      </div>
+      <div>
+        <Label htmlFor="unit_price">Preço unitário</Label>
+        <Input
+          id="unit_price"
+          type="number"
+          step="0.01"
+          {...register("unit_price", { valueAsNumber: true })}
+        />
+        {errors.unit_price && (
+          <p className="text-sm text-destructive">
+            {errors.unit_price.message}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center space-x-2">
+        <Checkbox id="is_active" {...register("is_active")} />
+        <Label htmlFor="is_active">Ativo</Label>
+      </div>
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? "Salvando..." : "Salvar"}
+      </Button>
+    </form>
+  );
+}
+
+export default ProductForm;

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,0 +1,23 @@
+// src/types/product.ts
+
+export interface Product {
+  id: string;
+  company_id: string;
+  name: string;
+  description: string | null;
+  sku: string | null;
+  unit_price_cents: number;
+  unit: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProductPayload {
+  name: string;
+  description?: string | null;
+  sku?: string | null;
+  unit_price_cents: number;
+  unit?: string | null;
+  is_active?: boolean;
+}


### PR DESCRIPTION
## Summary
- define product types
- create reusable product form/dialog components
- implement product listing with create, edit and delete actions

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a87d2eda9483219a1a0342d285ad69