### PR TITLE
Allow null expiry date in client quotes

### DIFF
--- a/src/app/dashboard/companies/[id]/clients/page.tsx
+++ b/src/app/dashboard/companies/[id]/clients/page.tsx
@@ -154,7 +154,7 @@ export default function CompanyClientsPage() {
     async (payload: {
       client_id: string;
       quote_number: string;
-      expiry_date?: string;
+      expiry_date?: string | null;
       items?: any[];
     }) => {
       // garante items: []


### PR DESCRIPTION
## Summary
- allow `CreateQuoteDialog` callbacks to handle `null` expiry dates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b90f6c0c832192313820edf46614