### PR TITLE
feat: add theme switcher and command shortcuts

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -15,6 +15,8 @@ import { NavCompanies } from "@/components/nav-companies";
 import { NavDocuments } from "@/components/nav-documents";
 import { NavSecondary } from "@/components/nav-secondary";
 import { NavUser } from "@/components/nav-user";
+import { NavMain } from "@/components/nav-main";
+import { SidebarThemeToggle } from "@/components/sidebar-theme-toggle";
 import {
   Sidebar,
   SidebarContent,
@@ -23,8 +25,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarGroup,
-  SidebarGroupContent,
 } from "@/components/ui/sidebar";
 import { useUserData } from "@/hooks/useUserData";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -68,28 +68,6 @@ const documentsNavigation = [
   },
 ];
 
-// Componente para navegação principal
-function NavMain() {
-  return (
-    <SidebarGroup>
-      <SidebarGroupContent>
-        <SidebarMenu>
-          {mainNavigation.map((item) => (
-            <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton asChild tooltip={item.description}>
-                <Link href={item.url}>
-                  <item.icon />
-                  <span>{item.title}</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
-        </SidebarMenu>
-      </SidebarGroupContent>
-    </SidebarGroup>
-  );
-}
-
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { userData, isLoading, error } = useUserData();
 
@@ -123,7 +101,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       {/* Conteúdo principal */}
       <SidebarContent>
         {/* Dashboard Geral - sempre visível */}
-        <NavMain />
+        <NavMain items={mainNavigation} />
 
         {/* Empresas com accordion - seção principal */}
         <NavCompanies />
@@ -135,8 +113,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <NavSecondary items={secondaryNavigation} className="mt-auto" />
       </SidebarContent>
 
-      {/* Footer com dados do usuário */}
+      {/* Footer com dados do usuário e opções */}
       <SidebarFooter>
+        <SidebarThemeToggle />
         {isLoading ? (
           <div className="flex items-center gap-2 p-2">
             <Skeleton className="h-8 w-8 rounded-lg" />

--- a/src/components/clients/CreateClientAction.tsx
+++ b/src/components/clients/CreateClientAction.tsx
@@ -25,7 +25,7 @@ interface CreateClientActionProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   /** Conteúdo opcional que aciona o dialog (ex.: botão) */
-  trigger?: React.ReactNode;
+  trigger?: React.ReactNode | null;
 }
 
 export function CreateClientAction({
@@ -89,11 +89,11 @@ export function CreateClientAction({
   );
 
   const dialogTrigger =
-    trigger ?? (
+    trigger === undefined ? (
       <Button size="sm" className="flex items-center gap-2">
         + Novo cliente
       </Button>
-    );
+    ) : trigger;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/src/components/clients/CreateClientAction.tsx
+++ b/src/components/clients/CreateClientAction.tsx
@@ -21,16 +21,28 @@ interface CreateClientActionProps {
   companyId: string;
   onCreated?: (client: Client) => void;
   onSuccess?: () => void; // Novo callback para atualizar a tabela
+  /** Controle externo do estado do dialog */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Conteúdo opcional que aciona o dialog (ex.: botão) */
+  trigger?: React.ReactNode;
 }
 
 export function CreateClientAction({
   companyId,
   onCreated,
   onSuccess,
+  open: controlledOpen,
+  onOpenChange,
+  trigger,
 }: CreateClientActionProps) {
   const { post } = useApi();
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isControlled = controlledOpen !== undefined && onOpenChange;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = isControlled ? onOpenChange! : setUncontrolledOpen;
 
   const handleSubmit = useCallback(
     async (payload: ClientApiData) => {
@@ -66,20 +78,26 @@ export function CreateClientAction({
   );
 
   // Reset do estado quando o modal fecha
-  const handleOpenChange = useCallback((newOpen: boolean) => {
-    setOpen(newOpen);
-    if (!newOpen) {
-      setIsSubmitting(false);
-    }
-  }, []);
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      setOpen(newOpen);
+      if (!newOpen) {
+        setIsSubmitting(false);
+      }
+    },
+    [setOpen]
+  );
+
+  const dialogTrigger =
+    trigger ?? (
+      <Button size="sm" className="flex items-center gap-2">
+        + Novo cliente
+      </Button>
+    );
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        <Button size="sm" className="flex items-center gap-2">
-          + Novo cliente
-        </Button>
-      </DialogTrigger>
+      {dialogTrigger && <DialogTrigger asChild>{dialogTrigger}</DialogTrigger>}
 
       <DialogContent className="w-[95vw] max-w-4xl max-h-[95vh] overflow-hidden flex flex-col sm:w-[90vw] sm:max-h-[90vh]">
         <DialogHeader className="flex-shrink-0">

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -239,6 +239,7 @@ export function NavMain({
               companyId={companyId}
               open={clientDialogOpen}
               onOpenChange={setClientDialogOpen}
+              trigger={null}
             />
             <CreateQuoteDialog
               isOpen={quoteDialogOpen}

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -30,6 +30,11 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { CreateClientAction } from "@/components/clients/CreateClientAction";
+import { CreateQuoteDialog } from "@/components/quotes/CreateQuoteDialog";
+import { ProductDialog } from "@/components/products/ProductDialog";
+import { useActiveCompany } from "@/contexts/CompanyContext";
+import { useQuotes } from "@/hooks/useQuotes";
 
 // Definição dos comandos/atalhos disponíveis
 const quickCommands = [
@@ -40,21 +45,21 @@ const quickCommands = [
         title: "Novo Orçamento",
         description: "Criar um novo orçamento",
         icon: IconFileText,
-        action: "/dashboard/quotes/new",
+        action: "new-quote",
         keywords: ["orcamento", "quote", "novo", "criar"],
       },
       {
         title: "Novo Cliente",
         description: "Adicionar novo cliente",
         icon: IconUsers,
-        action: "/dashboard/clients/new",
+        action: "new-client",
         keywords: ["cliente", "client", "novo", "adicionar"],
       },
       {
         title: "Novo Produto",
         description: "Cadastrar novo produto",
         icon: IconPlus,
-        action: "/dashboard/products/new",
+        action: "new-product",
         keywords: ["produto", "product", "novo", "cadastrar"],
       },
       {
@@ -97,7 +102,14 @@ export function NavMain({
   }[];
 }) {
   const [open, setOpen] = useState(false);
+  const [clientDialogOpen, setClientDialogOpen] = useState(false);
+  const [quoteDialogOpen, setQuoteDialogOpen] = useState(false);
+  const [productDialogOpen, setProductDialogOpen] = useState(false);
   const router = useRouter();
+  const { companyId } = useActiveCompany();
+  const { createQuote, fetchClients, generateQuoteNumber } = useQuotes({
+    companyId: companyId || "",
+  });
 
   // Atalho de teclado para abrir o Command Dialog
   useEffect(() => {
@@ -115,7 +127,29 @@ export function NavMain({
   // Função para executar comandos
   const handleCommandSelect = (action: string) => {
     setOpen(false);
-    router.push(action);
+    switch (action) {
+      case "new-client":
+        setClientDialogOpen(true);
+        break;
+      case "new-quote":
+        setQuoteDialogOpen(true);
+        break;
+      case "new-product":
+        setProductDialogOpen(true);
+        break;
+      default:
+        router.push(action);
+    }
+  };
+
+  const handleCreateQuote = async (data: any) => {
+    const result = await createQuote(data);
+    if (result) {
+      setQuoteDialogOpen(false);
+      router.push(
+        `/dashboard/companies/${companyId}/quotes/${result.id}/edit`
+      );
+    }
   };
 
   return (
@@ -197,6 +231,30 @@ export function NavMain({
             </SidebarMenuItem>
           ))}
         </SidebarMenu>
+
+        {/* Dialogs acionados pelos atalhos */}
+        {companyId && (
+          <>
+            <CreateClientAction
+              companyId={companyId}
+              open={clientDialogOpen}
+              onOpenChange={setClientDialogOpen}
+            />
+            <CreateQuoteDialog
+              isOpen={quoteDialogOpen}
+              onClose={() => setQuoteDialogOpen(false)}
+              onSuccess={handleCreateQuote}
+              companyId={companyId}
+              onLoadClients={fetchClients}
+              onGenerateQuoteNumber={generateQuoteNumber}
+            />
+            <ProductDialog
+              companyId={companyId}
+              open={productDialogOpen}
+              onOpenChange={setProductDialogOpen}
+            />
+          </>
+        )}
       </SidebarGroupContent>
     </SidebarGroup>
   );

--- a/src/components/products/ProductDialog.tsx
+++ b/src/components/products/ProductDialog.tsx
@@ -13,12 +13,25 @@ interface ProductDialogProps {
   product?: Product;
   trigger?: React.ReactNode;
   onSuccess?: (product: Product) => void;
+  /** Controle externo do estado do dialog */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function ProductDialog({ companyId, product, trigger, onSuccess }: ProductDialogProps) {
+export function ProductDialog({
+  companyId,
+  product,
+  trigger,
+  onSuccess,
+  open: controlledOpen,
+  onOpenChange,
+}: ProductDialogProps) {
   const { post, put } = useApi();
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const open = controlledOpen !== undefined ? controlledOpen : uncontrolledOpen;
+  const setOpen = onOpenChange ?? setUncontrolledOpen;
 
   const handleSubmit = useCallback(
     async (values: ProductFormValues) => {
@@ -54,7 +67,7 @@ export function ProductDialog({ companyId, product, trigger, onSuccess }: Produc
         setIsSubmitting(false);
       }
     },
-    [companyId, post, put, product, onSuccess]
+    [companyId, post, put, product, onSuccess, setOpen]
   );
 
   const defaultValues = product
@@ -69,24 +82,26 @@ export function ProductDialog({ companyId, product, trigger, onSuccess }: Produc
     : undefined;
 
   return (
-  <Dialog open={open} onOpenChange={setOpen}>
-    {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
-    <DialogContent className="max-w-lg">
-      <DialogHeader>
-        <DialogTitle>{product ? "Editar produto" : "Novo produto"}</DialogTitle>
-        <DialogDescription>
-          {product
-            ? "Atualize as informações do produto."
-            : "Preencha os dados para criar um novo produto."}
-        </DialogDescription>
-      </DialogHeader>
-      <ProductForm
-        defaultValues={defaultValues}
-        onSubmit={handleSubmit}
-        isSubmitting={isSubmitting}
-      />
-    </DialogContent>
-  </Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {product ? "Editar produto" : "Novo produto"}
+          </DialogTitle>
+          <DialogDescription>
+            {product
+              ? "Atualize as informações do produto."
+              : "Preencha os dados para criar um novo produto."}
+          </DialogDescription>
+        </DialogHeader>
+        <ProductForm
+          defaultValues={defaultValues}
+          onSubmit={handleSubmit}
+          isSubmitting={isSubmitting}
+        />
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/sidebar-theme-toggle.tsx
+++ b/src/components/sidebar-theme-toggle.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+import { Sun, Moon, Monitor } from "lucide-react";
+import { useTheme } from "next-themes";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import {
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from "@/components/ui/sidebar";
+
+export function SidebarThemeToggle() {
+  const { setTheme } = useTheme();
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton>
+              <Sun className="size-4" />
+              <span>Tema</span>
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => setTheme("light")}>
+              <Sun className="mr-2 h-4 w-4" />
+              Claro
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setTheme("dark")}>
+              <Moon className="mr-2 h-4 w-4" />
+              Escuro
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setTheme("system")}>
+              <Monitor className="mr-2 h-4 w-4" />
+              Sistema
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- add theme switcher (light, dark, system) to sidebar
- integrate command palette in sidebar for quick actions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5f0c8b8948321a76bdf07f7cb2999