### PR TITLE
fix: avoid unauthorized dashboard requests

### DIFF
--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -1,7 +1,7 @@
 // src/components/layouts/DashboardLayout.tsx
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { CompanyProvider } from "@/contexts/CompanyContext";
@@ -76,31 +76,18 @@ export function DashboardLayout({
   className = "",
   fetchCompanies = true,
 }: DashboardLayoutProps) {
-  const { isAuthenticated, isLoading, validateSession } = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
-  const [hasValidated, setHasValidated] = useState(false);
-
-  // Validar sessão uma única vez no mount
-  useEffect(() => {
-    const validateAuth = async () => {
-      if (!hasValidated) {
-        await validateSession();
-        setHasValidated(true);
-      }
-    };
-
-    validateAuth();
-  }, [validateSession, hasValidated]);
 
   // Redirecionar para login quando sessão for inválida
   useEffect(() => {
-    if (hasValidated && !isLoading && !isAuthenticated) {
+    if (!isLoading && !isAuthenticated) {
       router.replace("/login");
     }
-  }, [isAuthenticated, isLoading, hasValidated, router]);
+  }, [isAuthenticated, isLoading, router]);
 
   // Loading enquanto valida
-  if (isLoading || !hasValidated) {
+  if (isLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
         <div className="text-center space-y-4">

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -141,7 +141,7 @@ export const useApi = () => {
               (errorData?.error as string) ||
               `Erro ${response.status}: ${response.statusText}`;
 
-            if (showErrorToast) {
+            if (showErrorToast && (response.status !== 401 || latestTokens?.accessToken)) {
               toast.error("Erro na operação", { description: errorMessage });
             }
 

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -2,6 +2,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { buildApiUrl } from "@/config/app";
 import { useApi } from "@/hooks/useApi";
+import { useAuth } from "@/contexts/AuthContext";
 import type { QuoteStatus } from "@/types/quote";
 
 export interface DashboardSummary {
@@ -36,12 +37,14 @@ export interface DashboardQuote {
 
 export function useDashboard() {
   const { get } = useApi();
+  const { tokens } = useAuth();
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
   const [timeline, setTimeline] = useState<TimelineItem[]>([]);
   const [quotations, setQuotations] = useState<DashboardQuote[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   const fetchData = useCallback(async () => {
+    if (!tokens?.accessToken) return;
     setIsLoading(true);
 
     const [summaryRes, timelineRes, quotesRes] = await Promise.all([
@@ -63,11 +66,13 @@ export function useDashboard() {
     }
 
     setIsLoading(false);
-  }, [get]);
+  }, [get, tokens?.accessToken]);
 
   useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    if (tokens?.accessToken) {
+      fetchData();
+    }
+  }, [fetchData, tokens?.accessToken]);
 
   return { summary, timeline, quotations, isLoading, refetch: fetchData };
 }


### PR DESCRIPTION
## Summary
- ensure dashboard fetch waits for auth token

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5f75bba68832197914a1a94ea8ec9