### PR TITLE
Ajusta geração de PDF para abrir no navegador

### DIFF
--- a/src/hooks/useQuotes.ts
+++ b/src/hooks/useQuotes.ts
@@ -375,7 +375,7 @@ export function useQuotes({ companyId }: UseQuotesOptions) {
         };
 
         const pdfRes = await apiCall<Blob>(
-          process.env.PDF_API_URL ?? "https://pdf.empresor.com.br/pdf",
+          process.env.PDF_API_URL ?? "https://pdfv2.empresor.com.br/pdf/view",
           {
             method: "POST",
             skipAuth: true,
@@ -420,28 +420,19 @@ export function useQuotes({ companyId }: UseQuotesOptions) {
               : new Blob([pdfBlob], { type: "application/pdf" });
           const blobUrl = URL.createObjectURL(blob);
 
-          const openInNewTab = () => {
-            const pdfWindow = window.open(blobUrl, "_blank", "noopener,noreferrer");
-            if (pdfWindow) {
-              pdfWindow.document.title = fileName;
-            } else {
-              const link = document.createElement("a");
-              link.href = blobUrl;
-              link.target = "_blank";
-              link.rel = "noopener noreferrer";
-              document.body.appendChild(link);
-              link.click();
-              document.body.removeChild(link);
-            }
-          };
-
-          openInNewTab();
+          const link = document.createElement("a");
+          link.href = blobUrl;
+          link.target = "_blank";
+          link.rel = "noopener noreferrer";
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
 
           setTimeout(() => {
             URL.revokeObjectURL(blobUrl);
           }, 300000);
 
-          toast.success("PDF gerado com sucesso", { id: toastId });
+          toast.success(`PDF "${fileName}" gerado com sucesso`, { id: toastId });
         } else {
           throw new Error("PDF não retornado");
         }

--- a/src/hooks/useQuotes.ts
+++ b/src/hooks/useQuotes.ts
@@ -374,7 +374,7 @@ export function useQuotes({ companyId }: UseQuotesOptions) {
           },
         };
 
-        const pdfRes = await apiCall<{ url?: string }>(
+        const pdfRes = await apiCall<Blob>(
           process.env.PDF_API_URL ?? "https://pdf.empresor.com.br/pdf",
           {
             method: "POST",
@@ -383,17 +383,67 @@ export function useQuotes({ companyId }: UseQuotesOptions) {
               "x-api-key":
                 process.env.PDF_API_KEY ??
                 "9dbfce7254de4aa79dd6224df978d83c1cfced4092d2bf8a098c520aa20f25de",
+              Accept: "application/pdf",
             },
             body: JSON.stringify(payload),
+            responseType: "blob",
           }
         );
 
-        const url = pdfRes.data?.url;
-        if (url) {
-          window.open(url, "_blank");
+        if (pdfRes.error) {
+          throw new Error(pdfRes.error);
+        }
+
+        const pdfBlob = pdfRes.data;
+
+        if (pdfBlob instanceof Blob && pdfBlob.size > 0) {
+          const disposition = pdfRes.headers?.get("content-disposition") ?? "";
+          const fallbackName = title?.toLowerCase().endsWith(".pdf")
+            ? title
+            : `${title ?? "document"}.pdf`;
+          const match = disposition.match(
+            /filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i
+          );
+          const encodedName = match?.[1] ?? match?.[2];
+          let fileName = fallbackName;
+          if (encodedName) {
+            try {
+              fileName = decodeURIComponent(encodedName);
+            } catch {
+              fileName = encodedName;
+            }
+          }
+
+          const blob =
+            pdfBlob.type === "application/pdf"
+              ? pdfBlob
+              : new Blob([pdfBlob], { type: "application/pdf" });
+          const blobUrl = URL.createObjectURL(blob);
+
+          const openInNewTab = () => {
+            const pdfWindow = window.open(blobUrl, "_blank", "noopener,noreferrer");
+            if (pdfWindow) {
+              pdfWindow.document.title = fileName;
+            } else {
+              const link = document.createElement("a");
+              link.href = blobUrl;
+              link.target = "_blank";
+              link.rel = "noopener noreferrer";
+              document.body.appendChild(link);
+              link.click();
+              document.body.removeChild(link);
+            }
+          };
+
+          openInNewTab();
+
+          setTimeout(() => {
+            URL.revokeObjectURL(blobUrl);
+          }, 300000);
+
           toast.success("PDF gerado com sucesso", { id: toastId });
         } else {
-          throw new Error("URL do PDF não retornada");
+          throw new Error("PDF não retornado");
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Erro ao gerar PDF";

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -42,13 +42,17 @@ export interface ApiResponse<T = unknown> {
   data: T | null;
   error: string | null;
   status: number;
+  headers?: Headers;
 }
+
+export type ApiResponseType = "json" | "text" | "blob" | "arrayBuffer";
 
 export interface ApiOptions extends Omit<RequestInit, "body"> {
   skipAuth?: boolean;
   showErrorToast?: boolean;
   showSuccessToast?: boolean;
   body?: BodyInit | null; // explicitando body para não conflitar
+  responseType?: ApiResponseType;
 }
 
 export interface ActivePlan {


### PR DESCRIPTION
## Summary
- adiciona suporte a respostas binárias e retorno de headers na tipagem do hook de API
- ajusta o hook `useApi` para aceitar o tipo de resposta esperado e tratar blobs/array buffers
- atualiza a geração de PDFs para consumir o blob retornado e abrir o arquivo no visualizador do navegador

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8658c8b8c8321bf74fe463c7cc7c8