### PR TITLE
Improve responsiveness of kanban and data tables

### DIFF
--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -200,8 +200,11 @@ export function DataTable<TData, TValue>({
         columnStorageKey={columnStorageKey}
       />
 
-      <div className="overflow-hidden rounded-lg border">
-        <Table className={tableClassName}>
+      <div className="rounded-lg border shadow-sm">
+        <Table
+          containerClassName="rounded-lg"
+          className={tableClassName}
+        >
           <TableHeader className="bg-muted">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className="border-b">

--- a/src/components/quotes/kanban/QuoteKanbanBoard.tsx
+++ b/src/components/quotes/kanban/QuoteKanbanBoard.tsx
@@ -187,9 +187,11 @@ function QuoteCard({ quote, status }: { quote: Quote; status: QuoteStatus }) {
 function StatusColumn({
   status,
   quotes,
+  className,
 }: {
   status: QuoteStatus;
   quotes: Quote[];
+  className?: string;
 }) {
   const { setNodeRef, isOver } = useDroppable({
     id: status,
@@ -203,11 +205,13 @@ function StatusColumn({
     <div
       ref={setNodeRef}
       className={cn(
-        "flex flex-col rounded-lg border bg-card transition-colors min-w-0 w-full max-w-full",
-        isOver && "bg-accent/50"
+        "flex h-full w-full min-w-[15rem] flex-col rounded-lg border bg-card transition-colors",
+        "sm:min-w-[16rem] lg:min-w-[18rem]",
+        isOver && "bg-accent/50",
+        className
       )}
     >
-      <div className="p-4 pb-2">
+      <div className="p-3 pb-2 sm:p-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2 min-w-0">
             <h3 className="font-semibold text-sm">{config.label}</h3>
@@ -219,7 +223,7 @@ function StatusColumn({
         <Separator className="mt-3" />
       </div>
 
-      <div className="flex-1 p-3 xl:p-4 pt-1 min-h-[500px]">
+      <div className="flex-1 p-2 pt-1 sm:p-3 lg:p-4 min-h-[420px] md:min-h-[460px] lg:min-h-[500px]">
         <SortableContext
           items={quotes.map((q) => q.id)}
           strategy={verticalListSortingStrategy}
@@ -316,8 +320,8 @@ export function QuoteKanbanBoard({
   const totalQuotes = quotes.length;
 
   return (
-    <div className="p-4 md:p-6 lg:p-8">
-      <div className="space-y-4 min-w-0 w-full max-w-full overflow-x-hidden">
+    <div className="p-3 md:p-4 lg:p-6 xl:p-8">
+      <div className="space-y-3 md:space-y-4 min-w-0 w-full max-w-full">
         <div className="flex items-center justify-between">
           <div className="min-w-0">
             <h2 className="text-lg font-semibold">Board de Cotações</h2>
@@ -353,20 +357,23 @@ export function QuoteKanbanBoard({
           onDragEnd={handleDragEnd}
           onDragCancel={handleDragCancel}
         >
-          {/* Grid responsivo sem scroll horizontal */}
-          <div
-            className={cn(
-              "hidden md:grid gap-4 min-w-0 w-full max-w-full overflow-x-hidden",
-              "grid-cols-[repeat(auto-fit,minmax(18rem,1fr))]"
-            )}
-          >
-            {statusOrder.map((status) => (
-              <StatusColumn
-                key={status}
-                status={status}
-                quotes={columns[status] || []}
-              />
-            ))}
+          <div className="hidden md:block">
+            <div
+              className={cn(
+                "grid grid-flow-col auto-cols-[minmax(15rem,1fr)]",
+                "gap-3 lg:gap-4",
+                "overflow-x-auto pb-2 pr-2",
+                "xl:[grid-auto-columns:minmax(18rem,1fr)]"
+              )}
+            >
+              {statusOrder.map((status) => (
+                <StatusColumn
+                  key={status}
+                  status={status}
+                  quotes={columns[status] || []}
+                />
+              ))}
+            </div>
           </div>
 
           <DragOverlay>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -4,11 +4,22 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+interface TableProps extends React.ComponentProps<"table"> {
+  containerClassName?: string
+}
+
+function Table({
+  className,
+  containerClassName,
+  ...props
+}: TableProps) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className={cn(
+        "relative w-full overflow-x-auto",
+        containerClassName
+      )}
     >
       <table
         data-slot="table"


### PR DESCRIPTION
## Summary
- tighten the quote kanban column layout with smaller padding, adaptive minimum heights, and a horizontally scrollable grid for medium viewports
- adjust the shared data table wrapper so tables keep rounded borders while allowing horizontal scrolling on narrow screens
- extend the generic Table component with an optional containerClassName prop used by the data table to style the scroll container

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c87ced5fb88321907f5436f0520e81